### PR TITLE
Formatting

### DIFF
--- a/workspaces/cli/src/pycwatch/cli/assets.py
+++ b/workspaces/cli/src/pycwatch/cli/assets.py
@@ -1,12 +1,15 @@
 """Commands related to assets."""
 
-from typing import Annotated, Optional
-
 import typer
-from rich import print
 
-from pycwatch.cli.utils import get_client
-from pycwatch.lib.conversion import converter
+from pycwatch.cli.utils import (
+    CursorOption,
+    FormatOption,
+    LimitOption,
+    OutputFormat,
+    echo,
+    get_client,
+)
 
 app = typer.Typer(name="assets", help="Get or list assets.")
 
@@ -14,19 +17,21 @@ app = typer.Typer(name="assets", help="Get or list assets.")
 @app.command(name="list")
 def list_assets(
     ctx: typer.Context,
-    cursor: Annotated[Optional[str], typer.Option()] = None,
-    limit: Annotated[Optional[int], typer.Option()] = None,
+    cursor: CursorOption = None,
+    limit: LimitOption = None,
+    style: FormatOption = OutputFormat.RECORDS,
 ) -> None:
     """List assets."""
     response = get_client(ctx).list_assets(cursor, limit)
-    print(converter.unstructure(response.result))
+    echo(response.result, style)
 
 
 @app.command(name="get")
 def get_asset(
     ctx: typer.Context,
     code: str = typer.Argument(..., help="Asset code."),
+    style: FormatOption = OutputFormat.RECORDS,
 ) -> None:
     """Get asset."""
     response = get_client(ctx).get_asset(code)
-    print(converter.unstructure(response.result))
+    echo(response.result, style)

--- a/workspaces/cli/src/pycwatch/cli/exchanges.py
+++ b/workspaces/cli/src/pycwatch/cli/exchanges.py
@@ -1,36 +1,39 @@
 """Commands related to exchanges."""
 
 import typer
-from rich import print
 
-from pycwatch.cli.utils import get_client
-from pycwatch.lib.conversion import converter
+from pycwatch.cli.utils import FormatOption, OutputFormat, echo, get_client
 
 app = typer.Typer(name="exchanges", help="Get or list exchanges.")
 
 
 @app.command(name="list")
-def list_exchanges(ctx: typer.Context) -> None:
+def list_exchanges(
+    ctx: typer.Context,
+    style: FormatOption = OutputFormat.RECORDS,
+) -> None:
     """List exchanges."""
     response = get_client(ctx).list_exchanges()
-    print(converter.unstructure(response.result))
+    echo(response.result, style)
 
 
 @app.command(name="get")
 def get_exchange(
     ctx: typer.Context,
     code: str = typer.Argument(..., help="Exchange code."),
+    style: FormatOption = OutputFormat.RECORDS,
 ) -> None:
     """Get exchange."""
     response = get_client(ctx).get_exchange(code)
-    print(converter.unstructure(response.result))
+    echo(response.result, style)
 
 
 @app.command(name="markets")
 def list_exchange_markets(
     ctx: typer.Context,
     code: str = typer.Argument(..., help="Exchange code."),
+    style: FormatOption = OutputFormat.RECORDS,
 ) -> None:
     """List exchange markets."""
     response = get_client(ctx).list_exchange_markets(code)
-    print(converter.unstructure(response.result))
+    echo(response.result, style)

--- a/workspaces/cli/src/pycwatch/cli/main.py
+++ b/workspaces/cli/src/pycwatch/cli/main.py
@@ -1,15 +1,13 @@
 """Main CLI entrypoint."""
 
 import typer
-from rich import print
 
 from pycwatch.cli.assets import app as assets_app
 from pycwatch.cli.exchanges import app as exchanges_app
 from pycwatch.cli.markets import app as markets_app
 from pycwatch.cli.pairs import app as pairs_app
-from pycwatch.cli.utils import get_client
+from pycwatch.cli.utils import FormatOption, OutputFormat, echo, get_client
 from pycwatch.lib import CryptoWatchClient
-from pycwatch.lib.conversion import converter
 
 app = typer.Typer(name="PyCwatch CLI")
 app.add_typer(assets_app)
@@ -19,10 +17,10 @@ app.add_typer(exchanges_app)
 
 
 @app.command()
-def info(ctx: typer.Context) -> None:
+def info(ctx: typer.Context, style: FormatOption = OutputFormat.RECORDS) -> None:
     """Get API info."""
     response = get_client(ctx).get_info()
-    print(converter.unstructure(response.result))
+    echo(response.result, style)
 
 
 @app.callback()

--- a/workspaces/cli/src/pycwatch/cli/markets.py
+++ b/workspaces/cli/src/pycwatch/cli/markets.py
@@ -3,10 +3,16 @@
 from typing import Annotated, Optional
 
 import typer
-from rich import print
 
-from pycwatch.cli.utils import get_client
-from pycwatch.lib.conversion import converter
+from pycwatch.cli.utils import (
+    CursorOption,
+    FormatOption,
+    LimitOption,
+    OutputFormat,
+    echo,
+    get_client,
+)
+from pycwatch.lib.models import MarketSummaryKey
 
 app = typer.Typer(name="markets", help="Get or list markets.")
 
@@ -14,69 +20,89 @@ app = typer.Typer(name="markets", help="Get or list markets.")
 @app.command(name="list")
 def list_markets(
     ctx: typer.Context,
-    cursor: Annotated[Optional[str], typer.Option()] = None,
-    limit: Annotated[Optional[int], typer.Option()] = None,
+    cursor: CursorOption = None,
+    limit: LimitOption = None,
+    style: FormatOption = OutputFormat.RECORDS,
 ) -> None:
     """List markets."""
     response = get_client(ctx).list_markets(cursor, limit)
-    print(converter.unstructure(response.result))
+    echo(response.result, style)
 
 
 @app.command(name="get")
-def get_market(ctx: typer.Context, exchange: str, pair: str) -> None:
+def get_market(
+    ctx: typer.Context,
+    exchange: str,
+    pair: str,
+    style: FormatOption = OutputFormat.RECORDS,
+) -> None:
     """Get a market."""
     response = get_client(ctx).get_market(exchange, pair)
-    print(converter.unstructure(response.result))
+    echo(response.result, style)
 
 
 @app.command(name="price")
-def get_market_price(ctx: typer.Context, exchange: str, pair: str) -> None:
+def get_market_price(
+    ctx: typer.Context,
+    exchange: str,
+    pair: str,
+    style: FormatOption = OutputFormat.RECORDS,
+) -> None:
     """Get a market price."""
     response = get_client(ctx).get_market_price(exchange, pair)
-    print(converter.unstructure(response.result))
+    echo(response.result, style)
 
 
 @app.command(name="prices")
 def list_market_prices(
     ctx: typer.Context,
-    cursor: Annotated[Optional[str], typer.Option()] = None,
-    limit: Annotated[Optional[int], typer.Option()] = None,
+    cursor: CursorOption = None,
+    limit: LimitOption = None,
+    style: FormatOption = OutputFormat.RECORDS,
 ) -> None:
     """Get a market price."""
     response = get_client(ctx).get_all_market_prices(cursor, limit)
-    print(converter.unstructure(response.result))
+    echo(response.result, style)
 
 
 @app.command(name="trades")
-def get_market_trades(
+def get_market_trades(  # noqa: PLR0913
     ctx: typer.Context,
     exchange: str,
     pair: str,
     since: Annotated[Optional[int], typer.Option()] = None,
-    limit: Annotated[Optional[int], typer.Option()] = None,
+    limit: LimitOption = None,
+    style: FormatOption = OutputFormat.RECORDS,
 ) -> None:
     """Get market trades."""
     response = get_client(ctx).get_market_trades(exchange, pair, since, limit)
-    print(converter.unstructure(response.result))
+    echo(response.result, style)
 
 
 @app.command(name="summary")
-def get_market_summary(ctx: typer.Context, exchange: str, pair: str) -> None:
+def get_market_summary(
+    ctx: typer.Context,
+    exchange: str,
+    pair: str,
+    style: FormatOption = OutputFormat.RECORDS,
+) -> None:
     """Get a market summary."""
     response = get_client(ctx).get_market_summary(exchange, pair)
-    print(converter.unstructure(response.result))
+    echo(response.result, style)
 
 
 @app.command(name="summaries")
 def list_market_summaries(
     ctx: typer.Context,
-    cursor: Annotated[Optional[str], typer.Option()] = None,
-    limit: Annotated[Optional[int], typer.Option()] = None,
-    key_by: Annotated[Optional[str], typer.Option()] = None,
+    cursor: CursorOption = None,
+    limit: LimitOption = None,
+    key_by: Annotated[Optional[MarketSummaryKey], typer.Option()] = None,
+    style: FormatOption = OutputFormat.RECORDS,
 ) -> None:
     """List market summaries."""
-    response = get_client(ctx).get_all_market_summaries(cursor, limit, key_by)
-    print(converter.unstructure(response.result))
+    key = None if key_by is None else MarketSummaryKey(key_by)
+    response = get_client(ctx).get_all_market_summaries(cursor, limit, key)
+    echo(response.result, style)
 
 
 @app.command(name="orderbook")
@@ -86,11 +112,12 @@ def get_market_orderbook(  # noqa: PLR0913
     pair: str,
     depth: Annotated[Optional[int], typer.Option("--depth", "-d")] = None,
     span: Annotated[Optional[int], typer.Option("--span", "-s")] = None,
-    limit: Annotated[Optional[int], typer.Option("--limit", "-l")] = None,
+    limit: LimitOption = None,
+    style: FormatOption = OutputFormat.RECORDS,
 ) -> None:
     """Get a market's order book."""
     response = get_client(ctx).get_market_order_book(exchange, pair, depth, span, limit)
-    print(converter.unstructure(response.result))
+    echo(response.result, style)
 
 
 @app.command(name="orderbook-liquidity")
@@ -98,10 +125,11 @@ def get_market_order_book_liquidity(
     ctx: typer.Context,
     exchange: str,
     pair: str,
+    style: FormatOption = OutputFormat.RECORDS,
 ) -> None:
     """Get a market's order book liquidity."""
     response = get_client(ctx).get_market_order_book_liquidity(exchange, pair)
-    print(converter.unstructure(response.result))
+    echo(response.result, style)
 
 
 @app.command(name="calculate")
@@ -110,10 +138,11 @@ def calculate_quote(
     exchange: str,
     pair: str,
     amount: float,
+    style: FormatOption = OutputFormat.RECORDS,
 ) -> None:
     """Get a live quote from the order book for a given buy & sell amount."""
     response = get_client(ctx).calculate_quote(exchange, pair, amount)
-    print(converter.unstructure(response.result))
+    echo(response.result, style)
 
 
 @app.command(name="ohlcv")
@@ -124,6 +153,7 @@ def get_market_ohlcv(  # noqa: PLR0913
     before: Annotated[Optional[int], typer.Option("-b", "--before")] = None,
     after: Annotated[Optional[int], typer.Option("-a", "--after")] = None,
     periods: Annotated[Optional[list[str]], typer.Option("-p", "--periods")] = None,
+    style: FormatOption = OutputFormat.RECORDS,
 ) -> None:
     """Get a market's OHLCV data."""
     periods_ = (
@@ -138,4 +168,4 @@ def get_market_ohlcv(  # noqa: PLR0913
         after,
         periods_,  # type: ignore[arg-type]
     )
-    print(converter.unstructure(response.result))
+    echo(response.result, style)

--- a/workspaces/cli/src/pycwatch/cli/pairs.py
+++ b/workspaces/cli/src/pycwatch/cli/pairs.py
@@ -1,12 +1,15 @@
 """Commands related to pairs."""
 
-from typing import Annotated, Optional
-
 import typer
-from rich import print
 
-from pycwatch.cli.utils import get_client
-from pycwatch.lib.conversion import converter
+from pycwatch.cli.utils import (
+    CursorOption,
+    FormatOption,
+    LimitOption,
+    OutputFormat,
+    echo,
+    get_client,
+)
 
 app = typer.Typer(name="pairs", help="Get or list pairs.")
 
@@ -14,19 +17,21 @@ app = typer.Typer(name="pairs", help="Get or list pairs.")
 @app.command(name="list")
 def list_pairs(
     ctx: typer.Context,
-    cursor: Annotated[Optional[str], typer.Option()] = None,
-    limit: Annotated[Optional[int], typer.Option()] = None,
+    cursor: CursorOption = None,
+    limit: LimitOption = None,
+    style: FormatOption = OutputFormat.RECORDS,
 ) -> None:
     """List pairs."""
-    result = get_client(ctx).list_pairs(cursor, limit)
-    print(converter.unstructure(result))
+    response = get_client(ctx).list_pairs(cursor, limit)
+    echo(response.result, style)
 
 
 @app.command(name="get")
 def get_pair(
     ctx: typer.Context,
     code: str = typer.Argument(..., help="Pair identifier."),
+    style: FormatOption = OutputFormat.RECORDS,
 ) -> None:
     """Get pair."""
-    result = get_client(ctx).get_pair(code)
-    print(converter.unstructure(result))
+    response = get_client(ctx).get_pair(code)
+    echo(response.result, style)

--- a/workspaces/cli/src/pycwatch/cli/utils.py
+++ b/workspaces/cli/src/pycwatch/cli/utils.py
@@ -1,12 +1,157 @@
 """Utils for CLI."""
 
-from typing import cast
+import csv
+import enum
+import io
+from collections.abc import Mapping, Sequence
+from typing import Annotated, Any, Optional, cast
 
+import attrs
 import typer
+from rich.console import Console
+from rich.table import Table
 
 from pycwatch.lib import CryptoWatchClient
+from pycwatch.lib.conversion import converter
+
+
+class OutputFormat(str, enum.Enum):
+    """Output format."""
+
+    RECORDS = "records"
+    OBJECTS = "objects"
+    JSON = "json"
+    CSV = "csv"
+    TABLE = "table"
+
+
+FormatOption = Annotated[
+    OutputFormat,
+    typer.Option("-f", "--format", help="The output format"),
+]
+LimitOption = Annotated[
+    Optional[int],
+    typer.Option("-l", "--limit", help="Maximum number of items to include"),
+]
+CursorOption = Annotated[
+    Optional[str],
+    typer.Option("-c", "--cursor", help="Cursor for pagination"),
+]
 
 
 def get_client(ctx: typer.Context) -> CryptoWatchClient:
     """Get client from context."""
     return cast(CryptoWatchClient, ctx.meta["client"])
+
+
+def echo(
+    output: attrs.AttrsInstance | Sequence[attrs.AttrsInstance] | Mapping[str, Any],
+    style: FormatOption,
+) -> None:
+    """Write output to stdout."""
+    console = Console()
+    match style:
+        case OutputFormat.RECORDS:
+            unstructured_data = converter.unstructure(output)
+            print_maybe_paged(console, unstructured_data)
+        case OutputFormat.OBJECTS:
+            print_maybe_paged(console, output)
+        case OutputFormat.JSON:
+            console.print_json(converter.dumps(output))
+        case OutputFormat.CSV:
+            unstructured_data = converter.unstructure(output)
+            if isinstance(output, dict):
+                unstructured_data = add_top_level_as_key(unstructured_data)
+            console.print(write_csv(unstructured_data).read())
+        case OutputFormat.TABLE:
+            unstructured_data = converter.unstructure(output)
+            if isinstance(output, dict):
+                unstructured_data = add_top_level_as_key(unstructured_data)
+            console.print(write_table(unstructured_data))
+
+
+def add_top_level_as_key(data: dict[str, Any]) -> list[dict[str, Any]]:
+    """Add the top level as a key."""
+    output = []
+    out_dict = {}
+    for key, value in data.items():
+        out_dict["key"] = key
+        if isinstance(value, dict):
+            out_dict.update(value)
+            output.append(out_dict)
+        elif isinstance(value, list):
+            for item in value:
+                output.append({**out_dict, **item})
+        else:
+            output.append({**out_dict, "value": value})
+    return output
+
+
+def print_maybe_paged(console: Console, data: Any, threshold: int = 20) -> None:
+    """Write output to stdout, paging if necessary."""
+    if isinstance(data, list) and len(data) > threshold:
+        with console.pager():
+            console.print(data)
+    else:
+        console.print(data)
+
+
+def write_table(data: dict[str, Any] | list[dict[str, Any]]) -> Table:
+    """Write output to a table."""
+    table = Table()
+    headers = data.keys() if isinstance(data, dict) else data[0].keys()
+    for header in headers:
+        table.add_column(header)
+    if isinstance(data, dict):
+        table.add_row(*dict_to_row(data))
+    else:
+        for item in data:
+            table.add_row(*dict_to_row(item))
+    return table
+
+
+def dict_to_row(data: dict[str, Any]) -> list[Any]:
+    """Write a dict to a table row."""
+    row: list[Any] = []
+    for value in data.values():
+        if isinstance(value, dict):
+            row.append(write_table(value))
+        elif isinstance(value, list):
+            row.append(", ".join([str(v) for v in value]))
+        else:
+            row.append(str(value))
+    return row
+
+
+def write_csv(data: dict[str, Any] | list[dict[str, Any]]) -> io.StringIO:
+    """Write output to an in-memory buffer as CSV."""
+    output = io.StringIO()
+    if isinstance(data, dict):
+        flattened_data = flatten_dict(data)
+        writer = csv.DictWriter(output, fieldnames=flattened_data.keys())
+        writer.writeheader()
+        writer.writerow(flattened_data)
+    else:
+        flattened_list = [flatten_dict(d) for d in data]
+        writer = csv.DictWriter(output, fieldnames=flattened_list[0].keys())
+        writer.writeheader()
+        for record in flattened_list:
+            writer.writerow(record)
+    output.seek(0)
+    return output
+
+
+def flatten_dict(
+    dictionary: dict[str, Any],
+    parent_key: str = "",
+    sep: str = "_",
+) -> dict[str, Any]:
+    """Flatten a nested dictionary structure."""
+    flattened_dict = {}
+    for key, value in dictionary.items():
+        new_key = parent_key + sep + key if parent_key else key
+        if isinstance(value, dict):
+            flattened_dict.update(flatten_dict(value, new_key, sep))
+        else:
+            flattened_dict[new_key] = value
+    return flattened_dict

--- a/workspaces/cli/src/pycwatch/cli/utils.py
+++ b/workspaces/cli/src/pycwatch/cli/utils.py
@@ -73,17 +73,14 @@ def echo(
 def add_top_level_as_key(data: dict[str, Any]) -> list[dict[str, Any]]:
     """Add the top level as a key."""
     output = []
-    out_dict = {}
     for key, value in data.items():
-        out_dict["key"] = key
         if isinstance(value, dict):
-            out_dict.update(value)
-            output.append(out_dict)
+            output.append({"key": key, **value})
         elif isinstance(value, list):
             for item in value:
-                output.append({**out_dict, **item})
+                output.append({"key": key, **item})
         else:
-            output.append({**out_dict, "value": value})
+            output.append({"key": key, "value": value})
     return output
 
 

--- a/workspaces/cli/tests/test_main.py
+++ b/workspaces/cli/tests/test_main.py
@@ -1,9 +1,11 @@
+import pytest
 from typer.testing import CliRunner
 
 from pycwatch.cli.main import app
 
 
-def test_info(runner: CliRunner) -> None:
+@pytest.mark.parametrize("style", ["records", "objects", "json", "csv", "table"])
+def test_info(runner: CliRunner, style: str) -> None:
     """Verify that the info command works."""
-    result = runner.invoke(app, ["info"])
+    result = runner.invoke(app, ["info", "-f", style])
     assert result.exit_code == 0

--- a/workspaces/cli/tests/test_markets.py
+++ b/workspaces/cli/tests/test_markets.py
@@ -1,3 +1,4 @@
+import pytest
 from typer.testing import CliRunner
 
 from pycwatch.cli.main import app
@@ -21,9 +22,10 @@ def test_get_market_price(runner: CliRunner) -> None:
     assert result.exit_code == 0
 
 
-def test_list_market_prices(runner: CliRunner) -> None:
+@pytest.mark.parametrize("style", ["records", "objects", "json", "csv", "table"])
+def test_list_market_prices(runner: CliRunner, style: str) -> None:
     """Verify that the list prices command works."""
-    result = runner.invoke(app, ["markets", "prices", "--limit", "10"])
+    result = runner.invoke(app, ["markets", "prices", "--limit", "1", "-f", style])
     assert result.exit_code == 0
 
 
@@ -39,9 +41,10 @@ def test_get_market_summary(runner: CliRunner) -> None:
     assert result.exit_code == 0
 
 
-def test_list_market_summaries(runner: CliRunner) -> None:
+@pytest.mark.parametrize("style", ["records", "objects", "json", "csv", "table"])
+def test_list_market_summaries(runner: CliRunner, style: str) -> None:
     """Verify that the list summaries command works."""
-    result = runner.invoke(app, ["markets", "summaries", "--limit", "10"])
+    result = runner.invoke(app, ["markets", "summaries", "--limit", "5", "-f", style])
     assert result.exit_code == 0
 
 
@@ -69,10 +72,11 @@ def test_calculate_quote(runner: CliRunner) -> None:
     assert result.exit_code == 0
 
 
-def test_get_market_ohlcv(runner: CliRunner) -> None:
+@pytest.mark.parametrize("style", ["records", "objects", "json", "csv", "table"])
+def test_get_market_ohlcv(runner: CliRunner, style: str) -> None:
     """Verify that the get ohlcv command works."""
     result = runner.invoke(
         app,
-        ["markets", "ohlcv", "kraken", "btceur", "-p", "1h"],
+        ["markets", "ohlcv", "kraken", "btceur", "-p", "1h", "-f", style],
     )
     assert result.exit_code == 0

--- a/workspaces/cli/tests/test_utils.py
+++ b/workspaces/cli/tests/test_utils.py
@@ -1,0 +1,44 @@
+from typing import Any
+
+import pytest
+
+from pycwatch.cli import utils
+
+
+@pytest.mark.parametrize(
+    ("dict_in", "expected"),
+    [
+        (
+            {"a": 1, "b": 2, "c": 3},
+            [
+                {"key": "a", "value": 1},
+                {"key": "b", "value": 2},
+                {"key": "c", "value": 3},
+            ],
+        ),
+        (
+            {"a": {"aa": 1, "ab": 2}, "b": {"ba": 3, "bb": 4}},
+            [
+                {"key": "a", "aa": 1, "ab": 2},
+                {"key": "b", "ba": 3, "bb": 4},
+            ],
+        ),
+        (
+            {
+                "a": [{"aa": 1, "ab": 2}, {"aa": 3, "ab": 4}],
+                "b": [{"ba": 5, "bb": 6}],
+            },
+            [
+                {"key": "a", "aa": 1, "ab": 2},
+                {"key": "a", "aa": 3, "ab": 4},
+                {"key": "b", "ba": 5, "bb": 6},
+            ],
+        ),
+    ],
+)
+def test_top_level_as_dict(
+    dict_in: dict[str, Any],
+    expected: list[dict[str, Any]],
+) -> None:
+    """Verify that the top level is added as a key."""
+    assert utils.add_top_level_as_key(dict_in) == expected

--- a/workspaces/lib/src/pycwatch/lib/conversion.py
+++ b/workspaces/lib/src/pycwatch/lib/conversion.py
@@ -10,10 +10,10 @@ else:
     from typing import Protocol
 
 import attrs
-import cattrs
 from cattrs.gen import make_dict_structure_fn, make_dict_unstructure_fn, override
+from cattrs.preconf.ujson import make_converter
 
-converter = cattrs.Converter()
+converter = make_converter()
 
 
 def to_cwatch_key(field_name: str) -> str:


### PR DESCRIPTION
Add formatting options:

- "pretty" - output as rich pretty printed test
- "objects" - also rich text but without unstructuring the response
- "json" - output as json
- "csv" - output as csv
- "table" - output as rich formatted terminal table

Also adds paging when the output is a list and there are more than 20 items.